### PR TITLE
Set devLogs to false by default

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -36,7 +36,7 @@ export default defineNuxtConfig({
     }
   },
   features: {
-    // Set this to false if the UI is freezing with infinite logs.
-    devLogs: true
+    // Some infinite warnings in dev mode blocking the app in browser. So, disabling it. Set it to True for debugging.
+    devLogs: false
   }
 })


### PR DESCRIPTION
### Changes Made:
- Updated `nuxt.config.ts` to set `devLogs` to `false` by default under the `features` section. This prevents infinite warnings from blocking the UI during development.

### Why
To avoid step 6 and 7 in these steps:


### Steps:
1. Ran `npm run dev` to start the development server.
2. Initially observed UI blocking issue.
3. Updated `nuxt.config.ts` to disable `devLogs` for smoother UI performance.
4. Verified that the UI functions correctly without blocking.
5. Added changes with `git add .`, committed them using `git commit -m 'add Feature A'`, and pushed to the repository.
6. Realized an exclusion in `nuxt.config.ts` was missed.
7. Updated the commit with `git commit -m "unset devLogs to false"` to correct the oversight.
  
