### PR TITLE
Fix: Vulnerability Preview always shows the same vuln

### DIFF
--- a/pages/scan/[scanner]/[scan]/index.vue
+++ b/pages/scan/[scanner]/[scan]/index.vue
@@ -25,10 +25,12 @@
     />
 
     <VunerabilityDetailDialog
+      v-model:loading="vulenrabilityLoading"
       v-model:model-value="vulnDetailsDialog"
       :vuln="selectedVulnerability"
       :scan-id="scanId"
       :scanner="scanner"
+      @after-leave="selectedVulnerability = null"
     />
 
     <DfBreadcrumbs
@@ -202,7 +204,9 @@
       </v-card-title>
       <v-divider />
       <VulnzTable
+        :vulnerability-preview-loading="vulenrabilityLoading"
         :vulnz="vulns"
+        :selected-vulnerability-key="selectedVulnerability !== null ? selectedVulnerability.key : null"
         @go-to-detail="goToDetail"
         @go-to-detail-new-tab="goToDetailNewTab"
         @show-vuln-details="showVulnDetails"
@@ -262,6 +266,7 @@ interface Data {
   stopScanDialog: boolean
   breadcrumbs: VulnerabilityDetailBreadcrumbsType
   assets: Array<OxoAssetType>
+  vulenrabilityLoading: boolean
 }
 export default defineComponent ({
   name: 'Index',
@@ -281,6 +286,7 @@ export default defineComponent ({
         name: '',
         apiKey: ''
       },
+      vulenrabilityLoading: false,
       vulnDetailsDialog: false,
       selectedVulnerability: null,
       options: {

--- a/project/scans/components/VulnzTable.vue
+++ b/project/scans/components/VulnzTable.vue
@@ -36,7 +36,9 @@
       <template #[`item.show`]="{ item }">
         <v-btn
           size="small"
-          variant="flat"
+          variant="text"
+          :disabled="vulnerabilityPreviewLoading === true && (item.key !== selectedVulnerabilityKey)"
+          :loading="vulnerabilityPreviewLoading === true && (item.key === selectedVulnerabilityKey)"
           icon="mdi-magnify"
           @click="showVulnDetails(item)"
         />
@@ -73,6 +75,14 @@ export default defineComponent({
       type: Array as () => Array<OxoVulnerabilityType>,
       required: true,
       default: () => []
+    },
+    vulnerabilityPreviewLoading: {
+      type: Boolean,
+      default: false
+    },
+    selectedVulnerabilityKey: {
+      type: String as () => string | null,
+      required: true
     }
   },
   emits: ['goToDetail', 'goToDetailNewTab', 'showVulnDetails'],

--- a/project/scans/components/VunerabilityDetailDialog.vue
+++ b/project/scans/components/VunerabilityDetailDialog.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="vulnerability-detail-container">
+  <div id="vulnerability-detail-container">
     <v-dialog
       ref="dialogRef"
       v-model="dialog"
@@ -9,6 +9,7 @@
       max-width="50%"
       transition="slide-x-transition"
       class="ml-auto"
+      @after-leave="$emit('afterLeave')"
     >
       <v-card
         class="dialog-card pa-2"
@@ -16,6 +17,7 @@
         style="min-height: 100vh"
       >
         <VulnerabilityDetail
+          v-model:loading="loading"
           :vuln-title="vulnKey"
           :scan-id="scanId"
           :scanner="scanner"
@@ -57,7 +59,7 @@ export default defineComponent({
       required: true
     }
   },
-  emits: ['update:modelValue'],
+  emits: ['update:modelValue', 'update:loading', 'afterLeave'],
   data(): Data {
     return {
       loading: false,
@@ -78,7 +80,32 @@ export default defineComponent({
     },
     dialog(val: boolean): void {
       this.$emit('update:modelValue', val)
+    },
+    loading(newVal) {
+      this.$emit('update:loading', newVal)
+      if (this.vuln !== null && this.vuln !== undefined) {
+        if (newVal === true) {
+          this.dialog = false
+        } else {
+          this.dialog = true
+        }
+      }
     }
   }
 })
 </script>
+
+<style lang="scss">
+#vulnerability-detail-container {
+  .v-dialog {
+    display: block;
+
+    & > .v-overlay__content {
+      margin-top: 3px;
+      margin-right: 3px;
+      position: absolute;
+      right: 0
+    }
+  }
+}
+</style>

--- a/project/scans/components/vulnz/VulnerabilityDetail.vue
+++ b/project/scans/components/vulnz/VulnerabilityDetail.vue
@@ -156,6 +156,7 @@ export default defineComponent({
       default: true
     }
   },
+  emits: ['update:loading'],
   data(): Data {
     return {
       scansService: new ScansService(this.$axios),
@@ -208,10 +209,14 @@ export default defineComponent({
   },
   watch: {
     async vulnTitle() {
+      this.currentPage = 1
       this.getVulnInfo = true
       this.vulnz = []
       this.references = {}
       await this.fetchData()
+    },
+    loading(newVal: boolean) {
+      this.$emit('update:loading', newVal)
     }
   },
   async mounted() {


### PR DESCRIPTION
Issues fixed:
- Vulnerability preview dialog always shows the same vuln -> **Reset the `currentPage` to 1 when `selectedVulnerability` changes**.
- Vulnerability preview does not show technical details and references -> **Reset the `currentPage` to 1 when `selectedVulnerability` changes**.
- Vulnerability preview briefly shows the previously selected vuln before showing the new one -> **Only open the preview dialog after the current/selected vuln finishes loading**.

**Before**
[Screencast from 12-06-24 16:50:48.webm](https://github.com/Ostorlab/oxotitan/assets/121631800/62fb5a47-8a44-449a-9f58-efd87f18c8ba)

&nbsp;

**After**
[Screencast from 12-06-24 16:49:31.webm](https://github.com/Ostorlab/oxotitan/assets/121631800/1a61f20a-6fc8-4371-aa7c-0d34d0bd69cb)