### PR TITLE
Minor improvements

### DIFF
--- a/project/assets/components/OxoDomainAsset.vue
+++ b/project/assets/components/OxoDomainAsset.vue
@@ -16,7 +16,7 @@
     {{ domain.name }}
   </v-chip>
   <v-chip
-    v-if="showMore"
+    v-if="showMore === true"
     color="blue-lighten-1"
   >
     ...
@@ -33,9 +33,17 @@ export default defineComponent({
     }
   },
   computed: {
-    truncatedDomains() {
+    /**
+     * Truncate the domains to show only the first 5.
+     * @returns {Array<{ name: string }>}
+     */
+    truncatedDomains(): Array<{ name: string }> {
       return (this.asset.domainNames || []).slice(0, 5)
     },
+    /**
+     * Determine if there are more domains than the truncated domains.
+     * @returns {boolean}
+     */
     showMore(): boolean {
       return (this.asset?.networks?.length || 0) > 5
     }

--- a/project/assets/components/OxoDomainAsset.vue
+++ b/project/assets/components/OxoDomainAsset.vue
@@ -1,6 +1,6 @@
 <template>
   <v-chip
-    v-for="(link, index) in (asset.domainNames || [])"
+    v-for="(domain, index) in truncatedDomains"
     :key="index"
     class="ma-1"
     label
@@ -13,7 +13,13 @@
     >
       mdi-web
     </v-icon>
-    {{ link.name }}
+    {{ domain.name }}
+  </v-chip>
+  <v-chip
+    v-if="showMore"
+    color="blue-lighten-1"
+  >
+    ...
   </v-chip>
 </template>
 
@@ -24,6 +30,14 @@ export default defineComponent({
     asset: {
       type: Object,
       default: null
+    }
+  },
+  computed: {
+    truncatedDomains() {
+      return (this.asset.domainNames || []).slice(0, 5)
+    },
+    showMore(): boolean {
+      return (this.asset?.networks?.length || 0) > 5
     }
   }
 })

--- a/project/assets/components/OxoDomainAsset.vue
+++ b/project/assets/components/OxoDomainAsset.vue
@@ -15,12 +15,22 @@
     </v-icon>
     {{ domain.name }}
   </v-chip>
-  <v-chip
-    v-if="showMore === true"
-    color="blue-lighten-1"
-  >
-    ...
-  </v-chip>
+  <v-tooltip v-if="showMore === true">
+    <div
+      v-for="(domain, index) in asset?.domainNames || []"
+      :key="index"
+    >
+      {{ domain.name }}
+    </div>
+    <template #activator="{ props }">
+      <v-chip
+        v-bind="props"
+        color="blue-lighten-1"
+      >
+        ...
+      </v-chip>
+    </template>
+  </v-tooltip>
 </template>
 
 <script lang="ts">
@@ -38,14 +48,14 @@ export default defineComponent({
      * @returns {Array<{ name: string }>}
      */
     truncatedDomains(): Array<{ name: string }> {
-      return (this.asset.domainNames || []).slice(0, 5)
+      return (this.asset?.domainNames || []).slice(0, 5)
     },
     /**
      * Determine if there are more domains than the truncated domains.
      * @returns {boolean}
      */
     showMore(): boolean {
-      return (this.asset?.networks?.length || 0) > 5
+      return (this.asset?.domainNames?.length || 0) > 5
     }
   }
 })

--- a/project/assets/components/OxoNetworkAsset.vue
+++ b/project/assets/components/OxoNetworkAsset.vue
@@ -19,7 +19,7 @@
     <span v-else>{{ network.host }}</span>
   </v-chip>
   <v-chip
-    v-if="showMore"
+    v-if="showMore === true"
     color="grey-darken-2"
   >
     ...
@@ -27,7 +27,7 @@
 </template>
 
 <script lang="ts">
-import type { OxoNetworkAssetType } from '~/graphql/types'
+import type { Maybe, OxoIpRangeAssetType, OxoNetworkAssetType } from '~/graphql/types'
 
 export default defineComponent({
   name: 'OxoNetworkAsset',
@@ -38,9 +38,17 @@ export default defineComponent({
     }
   },
   computed: {
-    truncatedNetworks() {
+    /**
+     * Truncate the networks to show only the first 5.
+     * @returns {Array<Maybe<OxoIpRangeAssetType>>}
+     */
+    truncatedNetworks(): Array<Maybe<OxoIpRangeAssetType>> {
       return (this.asset?.networks || []).slice(0, 5)
     },
+    /**
+     * Determine if there are more networks than the truncated networks.
+     * @returns {boolean}
+     */
     showMore(): boolean {
       return (this.asset?.networks?.length || 0) > 5
     }

--- a/project/assets/components/OxoNetworkAsset.vue
+++ b/project/assets/components/OxoNetworkAsset.vue
@@ -18,12 +18,28 @@
     </span>
     <span v-else>{{ network.host }}</span>
   </v-chip>
-  <v-chip
-    v-if="showMore === true"
-    color="grey-darken-2"
-  >
-    ...
-  </v-chip>
+
+  <v-tooltip v-if="showMore === true">
+    <div
+      v-for="(network, index) in asset?.networks || []"
+      :key="index"
+    >
+      <span v-if="(network.mask || '').trim() !== ''">
+        {{ network.host }}/{{ network.mask }}
+      </span>
+      <span v-else>
+        {{ network.host }}
+      </span>
+    </div>
+    <template #activator="{ props }">
+      <v-chip
+        v-bind="props"
+        color="grey-darken-2"
+      >
+        ...
+      </v-chip>
+    </template>
+  </v-tooltip>
 </template>
 
 <script lang="ts">

--- a/project/assets/components/OxoNetworkAsset.vue
+++ b/project/assets/components/OxoNetworkAsset.vue
@@ -1,6 +1,6 @@
 <template>
   <v-chip
-    v-for="(network, index) in asset.networks"
+    v-for="(network, index) in truncatedNetworks"
     :key="index"
     label
     color="grey-darken-2"
@@ -18,6 +18,12 @@
     </span>
     <span v-else>{{ network.host }}</span>
   </v-chip>
+  <v-chip
+    v-if="showMore"
+    color="grey-darken-2"
+  >
+    ...
+  </v-chip>
 </template>
 
 <script lang="ts">
@@ -29,6 +35,14 @@ export default defineComponent({
     asset: {
       type: Object as () => OxoNetworkAssetType,
       default: null
+    }
+  },
+  computed: {
+    truncatedNetworks() {
+      return (this.asset?.networks || []).slice(0, 5)
+    },
+    showMore(): boolean {
+      return (this.asset?.networks?.length || 0) > 5
     }
   }
 })

--- a/project/assets/components/OxoUrlAsset.vue
+++ b/project/assets/components/OxoUrlAsset.vue
@@ -16,7 +16,7 @@
     {{ link.url }}
   </v-chip>
   <v-chip
-    v-if="showMore"
+    v-if="showMore === true"
     color="blue-lighten-1"
   >
     ...
@@ -24,20 +24,28 @@
 </template>
 
 <script lang="ts">
-import type { OxoUrlsAssetType } from '~/graphql/types'
+import type { Maybe, OxoLinkAssetType, OxoUrlsAssetType } from '~/graphql/types'
 
 export default defineComponent({
   name: 'OxoUrlAsset',
   props: {
     asset: {
-      type: Object as () => OxoUrlsAssetType,
+      type: Object as () => OxoUrlsAssetType | null,
       default: null
     }
   },
   computed: {
-    truncatedLinks() {
+    /**
+     * Truncate the links to show only the first 5.
+     * @returns {Array<Maybe<OxoLinkAssetType>>}
+     */
+    truncatedLinks(): Array<Maybe<OxoLinkAssetType>> {
       return (this.asset?.links || []).slice(0, 5)
     },
+    /**
+     * Determine if there are more links than the truncated links.
+     * @returns {boolean}
+     */
     showMore(): boolean {
       return (this.asset?.links?.length || 0) > 5
     }

--- a/project/assets/components/OxoUrlAsset.vue
+++ b/project/assets/components/OxoUrlAsset.vue
@@ -1,6 +1,6 @@
 <template>
   <v-chip
-    v-for="(link, index) in asset.links"
+    v-for="(link, index) in truncatedLinks"
     :key="index"
     class="ma-1"
     label
@@ -15,17 +15,31 @@
     </v-icon>
     {{ link.url }}
   </v-chip>
+  <v-chip
+    v-if="showMore"
+    color="blue-lighten-1"
+  >
+    ...
+  </v-chip>
 </template>
 
 <script lang="ts">
-import type { OxoUrlAssetType } from '~/graphql/types'
+import type { OxoUrlsAssetType } from '~/graphql/types'
 
 export default defineComponent({
   name: 'OxoUrlAsset',
   props: {
     asset: {
-      type: Object as () => OxoUrlAssetType,
+      type: Object as () => OxoUrlsAssetType,
       default: null
+    }
+  },
+  computed: {
+    truncatedLinks() {
+      return (this.asset?.links || []).slice(0, 5)
+    },
+    showMore(): boolean {
+      return (this.asset?.links?.length || 0) > 5
     }
   }
 })

--- a/project/assets/components/OxoUrlAsset.vue
+++ b/project/assets/components/OxoUrlAsset.vue
@@ -15,12 +15,22 @@
     </v-icon>
     {{ link.url }}
   </v-chip>
-  <v-chip
-    v-if="showMore === true"
-    color="blue-lighten-1"
-  >
-    ...
-  </v-chip>
+  <v-tooltip v-if="showMore === true">
+    <div
+      v-for="(link, index) in asset?.links || []"
+      :key="index"
+    >
+      {{ link.url }}
+    </div>
+    <template #activator="{ props }">
+      <v-chip
+        v-bind="props"
+        color="blue-lighten-1"
+      >
+        ...
+      </v-chip>
+    </template>
+  </v-tooltip>
 </template>
 
 <script lang="ts">

--- a/project/common/components/NavigationAppBar.vue
+++ b/project/common/components/NavigationAppBar.vue
@@ -26,11 +26,15 @@
         Menu
       </v-tooltip>
     </v-btn>
-    <img
-      src="/logo/oxo.png"
-      alt="OXO logo"
-      style="height:30px; object-fit: contain"
+    <a
+      href="/"
     >
+      <img
+        src="/logo/oxo.png"
+        alt="OXO logo"
+        style="height: 30px; object-fit: contain"
+      >
+    </a>
     <v-chip
       size="small"
       class="ml-2"

--- a/project/scans/components/form/CreateMobileScanFileForm.vue
+++ b/project/scans/components/form/CreateMobileScanFileForm.vue
@@ -47,6 +47,9 @@
         class="ml-2"
         @click="prev"
       >
+        <v-icon start>
+          mdi-skip-previous-outline
+        </v-icon>
         Previous
       </v-btn>
     </template>
@@ -57,7 +60,7 @@
     :create-scan-loading="createScanLoading"
     :step="step + 1"
     :selected-scanner="selectedScanner"
-    @reset="$emit('reset')"
+    @reset="clear"
     @create-scan="$emit('createScan')"
   />
 </template>
@@ -180,6 +183,7 @@ export default defineComponent({
   methods: {
     clear(): void {
       this.application = null
+      this.$emit('reset')
     },
     createScan() {}
   }

--- a/project/scans/components/form/CreateMobileScanStoreForm.vue
+++ b/project/scans/components/form/CreateMobileScanStoreForm.vue
@@ -40,6 +40,9 @@
         class="ml-2"
         @click="prev"
       >
+        <v-icon start>
+          mdi-skip-previous-outline
+        </v-icon>
         Previous
       </v-btn>
     </template>
@@ -50,7 +53,7 @@
     :create-scan-loading="createScanLoading"
     :step="step + 1"
     :selected-scanner="selectedScanner"
-    @reset="$emit('reset')"
+    @reset="clear"
     @create-scan="$emit('createScan')"
   />
 </template>
@@ -148,6 +151,7 @@ export default defineComponent({
   methods: {
     clear(): void {
       this.packageName = null
+      this.$emit('reset')
     }
   }
 })

--- a/project/scans/components/form/CreateNetworkScanForm.vue
+++ b/project/scans/components/form/CreateNetworkScanForm.vue
@@ -45,6 +45,9 @@
         class="ml-2"
         @click="prev"
       >
+        <v-icon start>
+          mdi-skip-previous-outline
+        </v-icon>
         Previous
       </v-btn>
     </template>
@@ -55,7 +58,7 @@
     :create-scan-loading="createScanLoading"
     :step="step + 1"
     :selected-scanner="selectedScanner"
-    @reset="$emit('reset')"
+    @reset="clear"
     @create-scan="$emit('createScan')"
   />
 </template>
@@ -189,6 +192,7 @@ export default defineComponent({
     clear(): void {
       this.ip = null
       this.userIps = []
+      this.$emit('reset')
     }
   }
 })

--- a/project/scans/components/form/CreateScanForm.vue
+++ b/project/scans/components/form/CreateScanForm.vue
@@ -66,6 +66,9 @@
               variant="elevated"
               @click="prev"
             >
+              <v-icon start>
+                mdi-skip-previous-outline
+              </v-icon>
               Previous
             </v-btn>
           </template>
@@ -101,6 +104,9 @@
               variant="elevated"
               @click="prev"
             >
+              <v-icon start>
+                mdi-skip-previous-outline
+              </v-icon>
               Previous
             </v-btn>
           </template>
@@ -187,6 +193,32 @@ export default defineComponent({
       assetPlatformType: AssetEnum.ANDROID_PLAYSTORE,
       assetTypeItems: [
         {
+          group: 'Web/Network',
+          assets: [
+            {
+              value: AssetEnum.WEB_APP,
+              title: 'Web App',
+              description: 'Web Application accessible using a browser',
+              icon: 'mdi-wan',
+              color: 'accent'
+            },
+            {
+              value: AssetEnum.WEB_API,
+              title: 'Web API',
+              description: 'Web API (REST, SOAP, GraphQL ...)',
+              icon: 'mdi-api',
+              color: 'accent'
+            },
+            {
+              value: AssetEnum.NETWORK,
+              title: 'Network',
+              description: 'Scan IPv4 and IPv6 network ranges',
+              icon: 'mdi-ip-network-outline',
+              color: 'accent'
+            }
+          ]
+        },
+        {
           group: 'Mobile',
           assets: [
             {
@@ -215,37 +247,6 @@ export default defineComponent({
               description: 'Scan an iOS Application (.IPA)',
               icon: 'mdi-apple',
               color: '#797979'
-            }
-          ]
-        },
-        {
-          group: 'Web',
-          assets: [
-            {
-              value: AssetEnum.WEB_APP,
-              title: 'Web App',
-              description: 'Web Application accessible using a browser',
-              icon: 'mdi-wan',
-              color: 'accent'
-            },
-            {
-              value: AssetEnum.WEB_API,
-              title: 'Web API',
-              description: 'Web API (REST, SOAP, GraphQL ...)',
-              icon: 'mdi-api',
-              color: 'accent'
-            }
-          ]
-        },
-        {
-          group: 'Network',
-          assets: [
-            {
-              value: AssetEnum.NETWORK,
-              title: 'Network',
-              description: 'Scan IPv4 and IPv6 network ranges',
-              icon: 'mdi-ip-network-outline',
-              color: 'accent'
             }
           ]
         },

--- a/project/scans/components/form/CreateScanForm.vue
+++ b/project/scans/components/form/CreateScanForm.vue
@@ -190,7 +190,7 @@ export default defineComponent({
       isStepValid: true,
       stepNumber: 1,
       finished: false,
-      assetPlatformType: AssetEnum.ANDROID_PLAYSTORE,
+      assetPlatformType: AssetEnum.WEB_APP,
       assetTypeItems: [
         {
           group: 'Web/Network',
@@ -375,7 +375,7 @@ export default defineComponent({
       this.agentGroupId = null
       this.selectedScanner = null
       this.scanTitle = null
-      this.assetPlatformType = AssetEnum.ANDROID_PLAYSTORE
+      this.assetPlatformType = AssetEnum.WEB_APP
     }
   }
 })

--- a/project/scans/components/form/CreateScanTargetAssetYamlForm.vue
+++ b/project/scans/components/form/CreateScanTargetAssetYamlForm.vue
@@ -39,6 +39,9 @@
         class="ml-2"
         @click="prev"
       >
+        <v-icon start>
+          mdi-skip-previous-outline
+        </v-icon>
         Previous
       </v-btn>
     </template>
@@ -67,6 +70,27 @@ name: master_scan
 assets:
   androidStore:
     - package_name: "com.example.test"
+  androidApkFile:
+    - path: /somepath/Downloads/app.apk
+  androidAabFile:
+    - path: /somepath/Downloads/app.aab
+  iosStore:
+    - bundle_id: "com.example1.test"
+    - bundle_id: "com.example2.test"
+  iosFile:
+    - path: /somepath/Downloads/ppk1.ipa
+    - url: https://somepath.com/storage/ppk2.ipa
+  link:
+    - url: "https://sketchy.com/fake"
+      method: "GET"
+    - url: "https://nasa.gov.ma/artemis"
+      method: "POST"
+  domain:
+    - name: "ostor.co"
+    - name: "seclab.dev"
+  ip:
+    - host: "10.21.11.11"
+      mask: "30"
     `
 
 export default defineComponent({

--- a/project/scans/components/form/CreateScanTargetAssetYamlForm.vue
+++ b/project/scans/components/form/CreateScanTargetAssetYamlForm.vue
@@ -68,6 +68,17 @@ description: Target group definition
 kind: targetGroup
 name: master_scan
 assets:
+  link:
+    - url: "https://sketchy.com/fake"
+      method: "GET"
+    - url: "https://nasa.gov.ma/artemis"
+      method: "POST"
+  domain:
+    - name: "ostor.co"
+    - name: "seclab.dev"
+  ip:
+    - host: "10.21.11.11"
+      mask: "30"
   androidStore:
     - package_name: "com.example.test"
   androidApkFile:
@@ -80,17 +91,6 @@ assets:
   iosFile:
     - path: /somepath/Downloads/ppk1.ipa
     - url: https://somepath.com/storage/ppk2.ipa
-  link:
-    - url: "https://sketchy.com/fake"
-      method: "GET"
-    - url: "https://nasa.gov.ma/artemis"
-      method: "POST"
-  domain:
-    - name: "ostor.co"
-    - name: "seclab.dev"
-  ip:
-    - host: "10.21.11.11"
-      mask: "30"
     `
 
 export default defineComponent({

--- a/project/scans/components/form/CreateScanYamlForm.vue
+++ b/project/scans/components/form/CreateScanYamlForm.vue
@@ -128,6 +128,9 @@
         class="ml-2"
         @click="prev"
       >
+        <v-icon start>
+          mdi-skip-previous-outline
+        </v-icon>
         Previous
       </v-btn>
       <v-btn

--- a/project/scans/components/form/CreateWebApiScanForm.vue
+++ b/project/scans/components/form/CreateWebApiScanForm.vue
@@ -43,6 +43,9 @@
         class="ml-2"
         @click="prev"
       >
+        <v-icon start>
+          mdi-skip-previous-outline
+        </v-icon>
         Previous
       </v-btn>
     </template>
@@ -53,7 +56,7 @@
     :create-scan-loading="createScanLoading"
     :step="step + 1"
     :selected-scanner="selectedScanner"
-    @reset="$emit('reset')"
+    @reset="clear"
     @create-scan="$emit('createScan')"
   />
 </template>
@@ -148,6 +151,7 @@ export default defineComponent({
      */
     clear(): void {
       this.rawUrls = null
+      this.$emit('reset')
     }
   }
 })

--- a/project/scans/components/form/CreateWebScanForm.vue
+++ b/project/scans/components/form/CreateWebScanForm.vue
@@ -43,6 +43,9 @@
         class="ml-2"
         @click="prev"
       >
+        <v-icon start>
+          mdi-skip-previous-outline
+        </v-icon>
         Previous
       </v-btn>
     </template>
@@ -53,7 +56,7 @@
     :create-scan-loading="createScanLoading"
     :step="step + 1"
     :selected-scanner="selectedScanner"
-    @reset="$emit('reset')"
+    @reset="clear"
     @create-scan="$emit('createScan')"
   />
 </template>
@@ -148,6 +151,7 @@ export default defineComponent({
      */
     clear(): void {
       this.rawUrls = null
+      this.$emit('reset')
     }
   }
 })


### PR DESCRIPTION
- [x] Previous button missing icon in new scan page.
- [x] Switch the order of the asset in the UI (web and network same line, then mobile, then yaml).
- [x] When clicking the logo, it should redirect to the home page.
- [x] In asset definition (new scan) it should include examples of all asset types and the user adjusts or instead we construct the asset definition from the user selection of the assets.
- [x] If scan is running on a lot of assets, display just some in the UI (UI lag if there are too many).
- [x] Reset is not working in the new scan page (if you select the same asset, it will still show what you filled).

[Screencast from 2024-07-19 11-51-17.webm](https://github.com/user-attachments/assets/816570a5-641f-4b89-ba33-d41991f83169)

