### PR TITLE
feat: add multi-select for asset types in agent group creation

### DIFF
--- a/graphql/types.ts
+++ b/graphql/types.ts
@@ -47,17 +47,6 @@ export enum AssetTypeEnum {
   Link = 'LINK'
 }
 
-/** Enum for the asset type icons. */
-export enum AssetTypeIconsEnum {
-  AndroidFile = 'mdi-android',
-  AndroidStore = 'mdi-google-play',
-  Domain = 'mdi-web',
-  File = 'mdi-file',
-  IosFile = 'mdi-apple-ios',
-  IosStore = 'mdi-apple',
-  Ip = 'mdi-network-outline',
-  Link = 'mdi-link-box-variant-outline'
-}
 
 /** Create asset mutation. */
 export type CreateAssetsMutation = {

--- a/graphql/types.ts
+++ b/graphql/types.ts
@@ -47,6 +47,18 @@ export enum AssetTypeEnum {
   Link = 'LINK'
 }
 
+/** Enum for the asset type icons. */
+export enum AssetTypeIconsEnum {
+  AndroidFile = 'mdi-android',
+  AndroidStore = 'mdi-google-play',
+  Domain = 'mdi-web',
+  File = 'mdi-file',
+  IosFile = 'mdi-apple-ios',
+  IosStore = 'mdi-apple',
+  Ip = 'mdi-network-outline',
+  Link = 'mdi-link-box-variant-outline'
+}
+
 /** Create asset mutation. */
 export type CreateAssetsMutation = {
   __typename?: 'CreateAssetsMutation';

--- a/project/agent-groups/components/AgentGroupForm.vue
+++ b/project/agent-groups/components/AgentGroupForm.vue
@@ -86,7 +86,7 @@
         <v-chip
           :key="item.value"
         >
-          {{ formatAssetType(item.title) }}
+          {{ assetTypeTitles[item.title] }}
         </v-chip>
       </template>
       <template #prepend-item>
@@ -101,7 +101,7 @@
               @click.stop="toggleSelectAll"
             />
             <v-list-item-title>
-              {{ isAllSelected ? 'Deselect All' : 'Select All' }}
+              {{ isAllSelected === true ? 'Deselect All' : 'Select All' }}
             </v-list-item-title>
           </div>
         </v-list-item>
@@ -124,7 +124,7 @@
               {{ item.raw.icon }}
             </v-icon>
             <v-list-item-title class="ml-3">
-              {{ formatAssetType(item.title) }}
+              {{ assetTypeTitles[item.title] }}
             </v-list-item-title>
           </div>
         </v-list-item>
@@ -163,7 +163,8 @@ import type { PropType } from 'vue'
 import Yaml from 'yaml'
 import { useNotificationsStore } from '~/stores/notifications'
 import ScannerForm from '~/project/scanners/components/ScannerForm.vue'
-import { type OxoAgentGroupType, AssetTypeEnum, AssetTypeIconsEnum } from '~/graphql/types'
+import { type OxoAgentGroupType, AssetTypeEnum } from '~/graphql/types'
+import { AssetTypeIconsEnum } from '~/utils/asset'
 import AgentGroupService from '~/project/agents/services/agentGroup.service'
 import type { Scanner } from '~/project/types'
 
@@ -202,6 +203,20 @@ const assetTypes: AssetType[] = Object.keys(AssetTypeEnum).map((key) => {
     icon: AssetTypeIconsEnum[key as keyof typeof AssetTypeIconsEnum]
   }
 })
+
+const formatAssetTypeTitle = (assetType: string): string => {
+  return assetType
+    .toLowerCase()
+    .split('_')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+}
+
+const assetTypeTitles = Object.values(AssetTypeEnum).reduce((acc, value) => {
+  acc[value] = formatAssetTypeTitle(value)
+  return acc
+}, {} as Record<string, string>)
+
 const selectedAssetTypes = ref<string[]>([])
 
 const isSelected = (item: AssetType): boolean => {
@@ -228,19 +243,11 @@ const isAllSelected = computed((): boolean =>
 )
 
 const toggleSelectAll = (): void => {
-  if (isAllSelected.value) {
+  if (isAllSelected.value === true) {
     selectedAssetTypes.value = []
   } else {
     selectedAssetTypes.value = assetTypes.map((item) => item.title)
   }
-}
-
-const formatAssetType = (assetType: string): string => {
-  return assetType
-    .toLowerCase()
-    .split('_')
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(' ')
 }
 
 const editorLanguage = 'yaml'

--- a/project/agent-groups/components/AgentGroupForm.vue
+++ b/project/agent-groups/components/AgentGroupForm.vue
@@ -85,7 +85,15 @@
       <template #selection="{ item }">
         <v-chip
           :key="item.value"
+          variant="outlined"
         >
+          <v-icon
+            class="ml-0"
+            size="18"
+            start
+          >
+            {{ item.raw.icon }}
+          </v-icon>
           {{ assetTypeTitles[item.title] }}
         </v-chip>
       </template>

--- a/project/agent-groups/components/AgentGroupForm.vue
+++ b/project/agent-groups/components/AgentGroupForm.vue
@@ -70,6 +70,17 @@
       label="Agent Group Description"
       placeholder="Agent Group Description"
     />
+    <v-select
+      v-model="selectedAssetTypes"
+      :items="assetTypes"
+      hide-details
+      variant="outlined"
+      density="compact"
+      clearable
+      multiple
+      label="Select Asset Types"
+      placeholder="Select Asset Types"
+    />
     <div class="mb-4">
       <v-label>
         Agent Group Definition
@@ -103,7 +114,7 @@ import type { PropType } from 'vue'
 import Yaml from 'yaml'
 import { useNotificationsStore } from '~/stores/notifications'
 import ScannerForm from '~/project/scanners/components/ScannerForm.vue'
-import { type OxoAgentGroupType } from '~/graphql/types'
+import { type OxoAgentGroupType, AssetTypeEnum } from '~/graphql/types'
 import AgentGroupService from '~/project/agents/services/agentGroup.service'
 import type { Scanner } from '~/project/types'
 
@@ -132,6 +143,8 @@ const emit = defineEmits(['close-form'])
 const notificationsStore = useNotificationsStore()
 const localAgentGroup = ref<OxoAgentGroupType>(DEFAULT_AGENTGROUP_VALUE)
 const yamlSource = ref<string>('')
+const assetTypes = ref<Array<string>>(Object.values(AssetTypeEnum))
+const selectedAssetTypes = ref<Array<string>>([])
 const editorLanguage = 'yaml'
 const editorOptions = {
   theme: 'vs',
@@ -176,7 +189,7 @@ const getAgentGroupInput = (yamlSource: string) => {
    * Add or update agent group information.
    */
 const onSubmit = async (): Promise<void> => {
-  if (isFormValid.value == true && localAgentGroup.value !== null) {
+  if (isFormValid.value === true && localAgentGroup.value !== null) {
     try {
       const agentGroupInput = getAgentGroupInput(yamlSource.value)
       if (localScanner.value !== null && agentGroupInput !== null && agentGroupInput !== undefined) {
@@ -189,7 +202,8 @@ const onSubmit = async (): Promise<void> => {
           agentGroup: {
             description: localAgentGroup.value.description || '',
             agents: agentGroupDefinition?.agents,
-            name: localAgentGroup.value.name
+            name: localAgentGroup.value.name,
+            assetTypes: selectedAssetTypes.value
           }
         })
       }

--- a/utils/asset.ts
+++ b/utils/asset.ts
@@ -62,3 +62,15 @@ export const parseIp = (ip: string): IPAssetInputType => {
     version
   }
 }
+
+/** Enum for the asset type icons. */
+export enum AssetTypeIconsEnum {
+  AndroidFile = 'mdi-android',
+  AndroidStore = 'mdi-google-play',
+  Domain = 'mdi-web',
+  File = 'mdi-file',
+  IosFile = 'mdi-apple-ios',
+  IosStore = 'mdi-apple',
+  Ip = 'mdi-network-outline',
+  Link = 'mdi-link-box-variant-outline'
+}


### PR DESCRIPTION
Add multi-select functionality for asset types in the agent group creation form


[Screencast from 04 شتنبر, 2024 +01 14:42:41.webm](https://github.com/user-attachments/assets/63008ab9-49cf-4d85-8e18-1746e565340d)
